### PR TITLE
Adding the ability to select specific cameras rather than just all of them

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -112,6 +112,10 @@ async fn download(args: &ArgMatches) {
             time_frame.0, time_frame.1
         );
         for camera in server.cameras_simple.iter() {
+            // check if camera name or id is in the list of cameras to download but if list contains all or * then download all
+            if !cameras.contains(&camera.name) && !cameras.contains(&camera.id) && !cameras.contains(&"*".to_string()) && !cameras.contains(&"all".to_string()) {
+                continue;
+            }
             let mut file_name = format!(
                 "{}-{}-{}.mp4",
                 time_frame.0.format("%Y-%m-%d-%H"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,10 @@ async fn download(args: &ArgMatches) {
     )
     .expect("Failed to parse end date");
 
+    let cameras: Vec<String> = args.get_many::<String>("cameras").unwrap().map(|s| s.to_string()).collect();
+
+    println!("Cameras to Download: {:?}", cameras);
+
     let mut server = UnifiProtectServer::new(args.get_one::<String>("uri").unwrap());
     println!("Logging in...");
     server

--- a/src/parse_args.rs
+++ b/src/parse_args.rs
@@ -65,6 +65,14 @@ pub fn parse_args() -> ArgMatches {
                         .value_parser(clap::value_parser!(String))
                         .help("The end date to download the files from (YYYY-MM-DD)")
                         .required(true),
+                )
+                .arg(
+                    clap::Arg::new("cameras")
+                        .value_name("cameras")
+                        .value_parser(clap::value_parser!(String))
+                        .help("A comma-separated list of cameras")
+                        .value_delimiter(',')
+                        .required(true),
                 ),
         );
 

--- a/src/parse_args.rs
+++ b/src/parse_args.rs
@@ -70,7 +70,7 @@ pub fn parse_args() -> ArgMatches {
                     clap::Arg::new("cameras")
                         .value_name("cameras")
                         .value_parser(clap::value_parser!(String))
-                        .help("A comma-separated list of cameras")
+                        .help("A comma-separated list of cameras if you want to download from specific cameras, or 'all'/'*' to download from all cameras")
                         .value_delimiter(',')
                         .required(true),
                 ),


### PR DESCRIPTION
You can still select all by passing * or all to the command entry for cameras or you can provide a coma seperated list of values of either cmaera ids or camera names and it will allow them to be downloaded if they match this will Close #1