### PR TITLE
Add hour-precision date range support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Arguments:
 - \<path>            The path to the directory to download the files to
 - \<mode>            The mode to download the files in (daily or hourly) [possible values: daily, hourly]
 - \<recording_type>  The type of recording to download (rotating or timelapse) [possible values: rotating, timelapse]
-- \<start_date>      The start date to download the files from (YYYY-MM-DD)
-- \<end_date>        The end date to download the files from (YYYY-MM-DD)
+- \<start_date>      The start date/time to download files from (YYYY-MM-DD or YYYY-MM-DD-HH)
+- \<end_date>        The end date/time to download files to (YYYY-MM-DD or YYYY-MM-DD-HH)
 
 
 # Example
@@ -34,8 +34,10 @@ In the above example, replace:
 4. __/path/to/destination/folder__ with the path to the folder where you want to download the footage to
 5. __daily__ with __hourly__ in case you want one video per camera per hour, rather than per day of footage
 6. __rotating__ with __timelapse__ in case you want to download timelapse footage rather than real time recordings
-6. __2023-06-01__ with the start date of the footage you want to download
-6. __2023-07-31__ with the end date of the footage you want to download
+6. __2023-06-01__ (or for hourly precision __2023-06-01-08__) with the start date/time of the footage you want to download
+6. __2023-07-31__ (or for hourly precision __2023-07-31-18__) with the end date/time of the footage you want to download
+
+To download only specific hours (for example daylight hours), use `hourly` mode with hour precision in the date inputs.
 
 ## GPL3 LICENSE SYNOPSIS
 TL;DR* Here's what the license entails:

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use crate::parse_args::{parse_args, Commands, DownloadArgs, DownloadMode};
-use chrono::{DateTime, Local, NaiveDateTime, TimeZone};
+use chrono::{DateTime, Duration, Local, NaiveDate, NaiveDateTime, TimeZone, Timelike};
 use std::path::Path;
 use unifi_protect::*;
 
@@ -17,14 +17,13 @@ async fn main() {
 }
 
 async fn download(args: &DownloadArgs) {
-    let start_date = NaiveDateTime::parse_from_str(
-        &(args.start_date.clone() + "-00:00:01"),
-        "%Y-%m-%d-%H:%M:%S",
-    )
-    .expect("Failed to parse start date");
-    let end_date =
-        NaiveDateTime::parse_from_str(&(args.end_date.clone() + "-00:00:01"), "%Y-%m-%d-%H:%M:%S")
-            .expect("Failed to parse end date");
+    let start_date =
+        parse_date_or_hour(&args.start_date, true).expect("Failed to parse start date");
+    let end_date = parse_date_or_hour(&args.end_date, false).expect("Failed to parse end date");
+
+    if end_date < start_date {
+        panic!("Invalid date range: end date/time is before start date/time");
+    }
 
     let cameras = args.cameras.clone();
 
@@ -61,44 +60,57 @@ async fn download(args: &DownloadArgs) {
     // Calculate time frames
     let mut time_frames: Vec<(DateTime<Local>, DateTime<Local>)> = vec![];
     if matches!(args.mode, DownloadMode::Hourly) {
-        for date in start_date.date().iter_days().take(
-            end_date
+        let mut cursor = start_date;
+        while cursor <= end_date {
+            let hour_start = cursor
                 .date()
-                .signed_duration_since(start_date.date())
-                .num_days() as usize
-                + 1,
-        ) {
-            for hour in 0..24 {
-                let start_time = date
-                    .and_hms_opt(hour, 0, 0)
-                    .expect("Failed to construct dateTime");
-                let end_time = date
-                    .and_hms_opt(hour, 59, 59)
-                    .expect("Failed to construct dateTime");
-                time_frames.push((
-                    Local.from_local_datetime(&start_time).unwrap(),
-                    Local.from_local_datetime(&end_time).unwrap(),
-                ));
-            }
+                .and_hms_opt(cursor.time().hour(), 0, 0)
+                .expect("Failed to construct dateTime");
+            let hour_end = hour_start + Duration::hours(1) - Duration::seconds(1);
+
+            let frame_start = if hour_start < start_date {
+                start_date
+            } else {
+                hour_start
+            };
+            let frame_end = if hour_end > end_date {
+                end_date
+            } else {
+                hour_end
+            };
+
+            time_frames.push((
+                Local.from_local_datetime(&frame_start).unwrap(),
+                Local.from_local_datetime(&frame_end).unwrap(),
+            ));
+            cursor = hour_start + Duration::hours(1);
         }
     } else if matches!(args.mode, DownloadMode::Daily) {
-        for date in start_date.date().iter_days().take(
-            end_date
-                .date()
-                .signed_duration_since(start_date.date())
-                .num_days() as usize
-                + 1,
-        ) {
-            let start_time = date
+        let mut date = start_date.date();
+        while date <= end_date.date() {
+            let day_start = date
                 .and_hms_opt(0, 0, 0)
                 .expect("Failed to construct dateTime");
-            let end_time = date
+            let day_end = date
                 .and_hms_opt(23, 59, 59)
                 .expect("Failed to construct dateTime");
+
+            let frame_start = if day_start < start_date {
+                start_date
+            } else {
+                day_start
+            };
+            let frame_end = if day_end > end_date {
+                end_date
+            } else {
+                day_end
+            };
+
             time_frames.push((
-                Local.from_local_datetime(&start_time).unwrap(),
-                Local.from_local_datetime(&end_time).unwrap(),
+                Local.from_local_datetime(&frame_start).unwrap(),
+                Local.from_local_datetime(&frame_end).unwrap(),
             ));
+            date = date.succ_opt().expect("Failed to calculate next date");
         }
     } else {
         println!("Invalid mode!");
@@ -173,4 +185,24 @@ async fn download(args: &DownloadArgs) {
         }
     }
     return;
+}
+
+fn parse_date_or_hour(
+    date_or_hour: &str,
+    is_start: bool,
+) -> Result<NaiveDateTime, chrono::ParseError> {
+    if let Ok(date_time) = NaiveDateTime::parse_from_str(date_or_hour, "%Y-%m-%d-%H") {
+        return Ok(date_time);
+    }
+
+    let date = NaiveDate::parse_from_str(date_or_hour, "%Y-%m-%d")?;
+    if is_start {
+        Ok(date
+            .and_hms_opt(0, 0, 0)
+            .expect("Failed to construct dateTime"))
+    } else {
+        Ok(date
+            .and_hms_opt(23, 59, 59)
+            .expect("Failed to construct dateTime"))
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -191,10 +191,12 @@ fn parse_date_or_hour(
     date_or_hour: &str,
     is_start: bool,
 ) -> Result<NaiveDateTime, chrono::ParseError> {
+    // try to parse as date-time (YYYY-MM-DD-HH)
     if let Ok(date_time) = NaiveDateTime::parse_from_str(date_or_hour, "%Y-%m-%d-%H") {
         return Ok(date_time);
     }
 
+    // hourly parsing failed, try to parse as date (YYYY-MM-DD)
     let date = NaiveDate::parse_from_str(date_or_hour, "%Y-%m-%d")?;
     if is_start {
         Ok(date

--- a/src/parse_args.rs
+++ b/src/parse_args.rs
@@ -35,9 +35,9 @@ pub struct DownloadArgs {
     pub mode: DownloadMode,
     /// The type of recording to download.
     pub recording_type: RecordingType,
-    /// The start date to download files from (YYYY-MM-DD).
+    /// The start date/time to download files from (YYYY-MM-DD or YYYY-MM-DD-HH).
     pub start_date: String,
-    /// The end date to download files to (YYYY-MM-DD).
+    /// The end date/time to download files to (YYYY-MM-DD or YYYY-MM-DD-HH).
     pub end_date: String,
     /// Comma-separated list of camera names/ids, or `all` / `*`.
     #[arg(value_delimiter = ',')]


### PR DESCRIPTION
### Motivation
- Allow users to request footage with hour precision so downloads can be limited to specific hours (e.g. daylight) instead of always pulling whole days.

### Description
- Add `parse_date_or_hour` which accepts `YYYY-MM-DD` or `YYYY-MM-DD-HH` and normalizes date-only inputs to day boundaries and hour inputs to that hour as a `NaiveDateTime`.
- Update timeframe generation for `hourly` and `daily` modes to honor partial start/end boundaries and produce frames clipped to the provided date/time range.
- Validate that the end date/time is not before the start date/time and panic with a clear message if it is invalid.
- Update CLI argument documentation in `src/parse_args.rs` and usage examples in `README.md` to document `YYYY-MM-DD` or `YYYY-MM-DD-HH` inputs and the daylight-hours use case.

### Testing
- Ran `cargo fmt` which completed successfully.
- Ran `cargo check` which completed successfully and the project builds.
- Ran `cargo test` which completed successfully (test run finished with no failing tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcf335d3f4832ca90be3cade6a48ed)