### PR TITLE
Check output path before downloading

### DIFF
--- a/src/app_error.rs
+++ b/src/app_error.rs
@@ -1,5 +1,7 @@
 use chrono::{DateTime, Local, LocalResult, NaiveDateTime, TimeZone};
 use std::fmt;
+use std::io;
+use std::path::PathBuf;
 
 #[derive(Debug)]
 pub enum AppError {
@@ -22,6 +24,19 @@ pub enum AppError {
     },
     InvalidMode {
         mode: String,
+    },
+    OutputPathInaccessible {
+        path: PathBuf,
+        existing_parent: Option<PathBuf>,
+        missing_path: Option<PathBuf>,
+        source: io::Error,
+    },
+    OutputPathNotDirectory {
+        path: PathBuf,
+    },
+    OutputPathNotWritable {
+        path: PathBuf,
+        source: io::Error,
     },
     Api {
         context: String,
@@ -57,6 +72,38 @@ impl fmt::Display for AppError {
             }
             AppError::DateOverflow { context } => write!(f, "date arithmetic failed: {}", context),
             AppError::InvalidMode { mode } => write!(f, "invalid download mode '{}'", mode),
+            AppError::OutputPathInaccessible {
+                path,
+                existing_parent: Some(existing_parent),
+                missing_path: Some(missing_path),
+                source,
+            } => write!(
+                f,
+                "pre-download output path check failed: '{}' is not accessible: path exists up to '{}', but '{}' does not exist ({})",
+                path.display(),
+                existing_parent.display(),
+                missing_path.display(),
+                source
+            ),
+            AppError::OutputPathInaccessible { path, source, .. } => write!(
+                f,
+                "pre-download output path check failed: '{}' is not accessible: {}",
+                path.display(),
+                source
+            ),
+            AppError::OutputPathNotDirectory { path } => {
+                write!(
+                    f,
+                    "pre-download output path check failed: '{}' is not a directory",
+                    path.display()
+                )
+            }
+            AppError::OutputPathNotWritable { path, source } => write!(
+                f,
+                "pre-download output path check failed: '{}' is not writable: {}",
+                path.display(),
+                source
+            ),
             AppError::Api { context, source } => write!(f, "{}: {}", context, source),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use unifi_protect::*;
 
 mod app_error;
+mod output_path;
 mod parse_args;
 
 #[tokio::main]
@@ -22,6 +23,8 @@ async fn main() {
 }
 
 async fn download(args: &DownloadArgs) -> Result<(), AppError> {
+    output_path::validate(Path::new(&args.out_path), args.probe_output_path)?;
+
     let start_date = parse_date_or_hour(&args.start_date, true)
         .map_err(|source| AppError::parse_date(&args.start_date, source))?;
     let end_date = parse_date_or_hour(&args.end_date, false)

--- a/src/output_path.rs
+++ b/src/output_path.rs
@@ -1,0 +1,113 @@
+use crate::app_error::AppError;
+use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const PROBE_ATTEMPTS: usize = 10;
+
+pub fn validate(out_path: &Path, probe_writable: bool) -> Result<(), AppError> {
+    let metadata = fs::metadata(out_path).map_err(|source| {
+        let (existing_parent, missing_path) = if source.kind() == io::ErrorKind::NotFound {
+            first_missing_path(out_path)
+        } else {
+            (None, None)
+        };
+
+        AppError::OutputPathInaccessible {
+            path: out_path.to_path_buf(),
+            existing_parent,
+            missing_path,
+            source,
+        }
+    })?;
+
+    if !metadata.is_dir() {
+        return Err(AppError::OutputPathNotDirectory {
+            path: out_path.to_path_buf(),
+        });
+    }
+
+    if metadata.permissions().readonly() {
+        return Err(AppError::OutputPathNotWritable {
+            path: out_path.to_path_buf(),
+            source: io::Error::new(io::ErrorKind::PermissionDenied, "path is read-only"),
+        });
+    }
+
+    if probe_writable {
+        probe(out_path)?;
+    }
+
+    Ok(())
+}
+
+fn first_missing_path(path: &Path) -> (Option<PathBuf>, Option<PathBuf>) {
+    let mut existing_parent = None;
+    let mut candidate = PathBuf::new();
+
+    for component in path.components() {
+        candidate.push(component.as_os_str());
+
+        if candidate.exists() {
+            existing_parent = Some(candidate.clone());
+        } else {
+            return (existing_parent, Some(candidate));
+        }
+    }
+
+    (existing_parent, None)
+}
+
+fn probe(out_path: &Path) -> Result<(), AppError> {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+
+    for attempt in 0..PROBE_ATTEMPTS {
+        let test_path = out_path.join(format!(
+            ".unifi-protect-bulk-download-write-test-{}-{}-{}",
+            std::process::id(),
+            timestamp,
+            attempt
+        ));
+
+        let mut file = match fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&test_path)
+        {
+            Ok(file) => file,
+            Err(source) if source.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(source) => {
+                return Err(AppError::OutputPathNotWritable {
+                    path: out_path.to_path_buf(),
+                    source,
+                });
+            }
+        };
+
+        if let Err(source) = file.write_all(b"test") {
+            let _ = fs::remove_file(&test_path);
+            return Err(AppError::OutputPathNotWritable {
+                path: out_path.to_path_buf(),
+                source,
+            });
+        }
+        drop(file);
+
+        return fs::remove_file(&test_path).map_err(|source| AppError::OutputPathNotWritable {
+            path: out_path.to_path_buf(),
+            source,
+        });
+    }
+
+    Err(AppError::OutputPathNotWritable {
+        path: out_path.to_path_buf(),
+        source: io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "could not create a unique output path probe file without overwriting an existing file",
+        ),
+    })
+}

--- a/src/parse_args.rs
+++ b/src/parse_args.rs
@@ -42,6 +42,9 @@ pub struct DownloadArgs {
     /// Comma-separated list of camera names/ids, or `all` / `*`.
     #[arg(value_delimiter = ',')]
     pub cameras: Vec<String>,
+    /// Create and remove a test file in the output directory before downloading.
+    #[arg(long)]
+    pub probe_output_path: bool,
 }
 
 #[derive(Clone, Debug, ValueEnum)]


### PR DESCRIPTION
## Summary
- Validate the output path before logging into UniFi Protect or starting downloads
- Fail fast when the destination is inaccessible, missing part of the path, not a directory, or read-only
- Add optional `--probe-output-path` to create/write/remove a test file for a stronger preflight check

Related to #5 and #6. This helps fail fast on invalid output destinations instead of waiting until the first video download attempts to create a file.

## Verification
- `cargo check`
- Smoke checked missing path reporting, file-not-directory reporting, default no-probe validation, and `--probe-output-path` cleanup